### PR TITLE
Move hero metadata into their own files

### DIFF
--- a/Metadata/Heroes/npc_dota_hero_abaddon.json
+++ b/Metadata/Heroes/npc_dota_hero_abaddon.json
@@ -1,0 +1,17 @@
+{
+  "id": 102,
+  "name": "npc_dota_hero_abaddon",
+  "localized_name": "Abaddon",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Support",
+    "Carry",
+    "Durable"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_abyssal_underlord.json
+++ b/Metadata/Heroes/npc_dota_hero_abyssal_underlord.json
@@ -1,0 +1,19 @@
+{
+  "id": 108,
+  "name": "npc_dota_hero_abyssal_underlord",
+  "localized_name": "Underlord",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Support",
+    "Nuker",
+    "Disabler",
+    "Durable",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_alchemist.json
+++ b/Metadata/Heroes/npc_dota_hero_alchemist.json
@@ -1,0 +1,20 @@
+{
+  "id": 73,
+  "name": "npc_dota_hero_alchemist",
+  "localized_name": "Alchemist",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Support",
+    "Durable",
+    "Disabler",
+    "Initiator",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_ancient_apparition.json
+++ b/Metadata/Heroes/npc_dota_hero_ancient_apparition.json
@@ -1,0 +1,17 @@
+{
+  "id": 68,
+  "name": "npc_dota_hero_ancient_apparition",
+  "localized_name": "Ancient Apparition",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Disabler",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_antimage.json
+++ b/Metadata/Heroes/npc_dota_hero_antimage.json
@@ -1,36 +1,38 @@
 {
-    "id": 1,
-    "name": "Anti-Mage",
-    "primary": "int",
-    "description": "",
-    "lore": "The monks of Turstarkuri watched the rugged valleys below their mountain monastery as wave after wave of invaders swept through the lower kingdoms. Ascetic and pragmatic, in their remote monastic eyrie they remained aloof from mundane strife, wrapped in meditation that knew no gods or elements of magic. Then came the Legion of the Dead God, crusaders with a sinister mandate to replace all local worship with their Unliving Lord's poisonous nihilosophy. From a landscape that had known nothing but blood and battle for a thousand years, they tore the souls and bones of countless fallen legions and pitched them against Turstarkuri. The monastery stood scarcely a fortnight against the assault, and the few monks who bothered to surface from their meditations believed the invaders were but demonic visions sent to distract them from meditation. They died where they sat on their silken cushions. Only one youth survived--a pilgrim who had come as an acolyte, seeking wisdom, but had yet to be admitted to the monastery. He watched in horror as the monks to whom he had served tea and nettles were first slaughtered, then raised to join the ranks of the Dead God's priesthood. With nothing but a few of Turstarkuri's prized dogmatic scrolls, he crept away to the comparative safety of other lands, swearing to obliterate not only the Dead God's magic users--but to put an end to magic altogether.",
-    "image": "",
-    "aliases": [
-        "anti mage",
-        "anti-mage",
-        "am",
-        "animage"
-    ],
-    "skills": [
-        {
-            "name": "Mana Break",
-            "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/c/c1/Mana_Break_icon.png?version=0f9ecc20cc314a54d5b23c719f249396",
-            "link": "http://dota2.gamepedia.com/Anti-Mage#Mana_Break"
-        },
-        {
-            "name": "Blink",
-            "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/c/ce/Blink_%28Anti-Mage%29_icon.png?version=7c40b943872d402ffaed1749b885e6e4",
-            "link": "http://dota2.gamepedia.com/Anti-Mage#Blink"
-        },
-        {
-            "name": "Spell Shield",
-            "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/a/a6/Spell_Shield_icon.png?version=2479009df0c60bfddc3d989fa3e66e68",
-            "link": "http://dota2.gamepedia.com/Anti-Mage#Spell_Shield"
-        },
-        {
-            "name": "Mana Void",
-            "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/f/fe/Mana_Void_icon.png?version=74210e75d8c842248b142e23d2f3a621",
-            "link": "http://dota2.gamepedia.com/Anti-Mage#Mana_Void"
-        }
-    ]
+  "id": 1,
+  "name": "npc_dota_hero_antimage",
+  "localized_name": "Anti-Mage",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Escape",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Mana Break",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/c/c1/Mana_Break_icon.png?version=0f9ecc20cc314a54d5b23c719f249396",
+      "link": "http://dota2.gamepedia.com/Anti-Mage#Mana_Break"
+    },
+    {
+      "name": "Blink",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/c/ce/Blink_%28Anti-Mage%29_icon.png?version=7c40b943872d402ffaed1749b885e6e4",
+      "link": "http://dota2.gamepedia.com/Anti-Mage#Blink"
+    },
+    {
+      "name": "Spell Shield",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/a/a6/Spell_Shield_icon.png?version=2479009df0c60bfddc3d989fa3e66e68",
+      "link": "http://dota2.gamepedia.com/Anti-Mage#Spell_Shield"
+    },
+    {
+      "name": "Mana Void",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/f/fe/Mana_Void_icon.png?version=74210e75d8c842248b142e23d2f3a621",
+      "link": "http://dota2.gamepedia.com/Anti-Mage#Mana_Void"
+    }
+  ]
 }

--- a/Metadata/Heroes/npc_dota_hero_antimage.json
+++ b/Metadata/Heroes/npc_dota_hero_antimage.json
@@ -1,0 +1,36 @@
+{
+    "id": 1,
+    "name": "Anti-Mage",
+    "primary": "int",
+    "description": "",
+    "lore": "The monks of Turstarkuri watched the rugged valleys below their mountain monastery as wave after wave of invaders swept through the lower kingdoms. Ascetic and pragmatic, in their remote monastic eyrie they remained aloof from mundane strife, wrapped in meditation that knew no gods or elements of magic. Then came the Legion of the Dead God, crusaders with a sinister mandate to replace all local worship with their Unliving Lord's poisonous nihilosophy. From a landscape that had known nothing but blood and battle for a thousand years, they tore the souls and bones of countless fallen legions and pitched them against Turstarkuri. The monastery stood scarcely a fortnight against the assault, and the few monks who bothered to surface from their meditations believed the invaders were but demonic visions sent to distract them from meditation. They died where they sat on their silken cushions. Only one youth survived--a pilgrim who had come as an acolyte, seeking wisdom, but had yet to be admitted to the monastery. He watched in horror as the monks to whom he had served tea and nettles were first slaughtered, then raised to join the ranks of the Dead God's priesthood. With nothing but a few of Turstarkuri's prized dogmatic scrolls, he crept away to the comparative safety of other lands, swearing to obliterate not only the Dead God's magic users--but to put an end to magic altogether.",
+    "image": "",
+    "aliases": [
+        "anti mage",
+        "anti-mage",
+        "am",
+        "animage"
+    ],
+    "skills": [
+        {
+            "name": "Mana Break",
+            "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/c/c1/Mana_Break_icon.png?version=0f9ecc20cc314a54d5b23c719f249396",
+            "link": "http://dota2.gamepedia.com/Anti-Mage#Mana_Break"
+        },
+        {
+            "name": "Blink",
+            "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/c/ce/Blink_%28Anti-Mage%29_icon.png?version=7c40b943872d402ffaed1749b885e6e4",
+            "link": "http://dota2.gamepedia.com/Anti-Mage#Blink"
+        },
+        {
+            "name": "Spell Shield",
+            "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/a/a6/Spell_Shield_icon.png?version=2479009df0c60bfddc3d989fa3e66e68",
+            "link": "http://dota2.gamepedia.com/Anti-Mage#Spell_Shield"
+        },
+        {
+            "name": "Mana Void",
+            "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/f/fe/Mana_Void_icon.png?version=74210e75d8c842248b142e23d2f3a621",
+            "link": "http://dota2.gamepedia.com/Anti-Mage#Mana_Void"
+        }
+    ]
+}

--- a/Metadata/Heroes/npc_dota_hero_arc_warden.json
+++ b/Metadata/Heroes/npc_dota_hero_arc_warden.json
@@ -1,0 +1,17 @@
+{
+  "id": 113,
+  "name": "npc_dota_hero_arc_warden",
+  "localized_name": "Arc Warden",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Escape",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_axe.json
+++ b/Metadata/Heroes/npc_dota_hero_axe.json
@@ -1,0 +1,39 @@
+{
+  "id": 2,
+  "name": "npc_dota_hero_axe",
+  "localized_name": "Axe",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Initiator",
+    "Durable",
+    "Disabler",
+    "Jungler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Berserker's Call",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/d/d1/Berserker%27s_Call_icon.png?version=f15b2131acf66e1f8ff6d2a4ea8d2c1b",
+      "link": "http://dota2.gamepedia.com/Axe#Berserker.27s_Call"
+    },
+    {
+      "name": "Battle Hunger",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/0/00/Battle_Hunger_icon.png?version=034d7d418ace647b7b24e5b041c6d43b",
+      "link": "http://dota2.gamepedia.com/Axe#Battle_Hunger"
+    },
+    {
+      "name": "Counter Helix",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/1/14/Counter_Helix_icon.png?version=47275d1f40ddbfbe36e91ad03c514891",
+      "link": "http://dota2.gamepedia.com/Axe#Counter_Helix"
+    },
+    {
+      "name": "Culling Blade",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/3/30/Culling_Blade_icon.png?version=f4780cf87ae32493be5393c651156c52",
+      "link": "http://dota2.gamepedia.com/Axe#Culling_Blade"
+    }
+  ]
+}

--- a/Metadata/Heroes/npc_dota_hero_bane.json
+++ b/Metadata/Heroes/npc_dota_hero_bane.json
@@ -1,0 +1,39 @@
+{
+  "id": 3,
+  "name": "npc_dota_hero_bane",
+  "localized_name": "Bane",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Disabler",
+    "Nuker",
+    "Durable"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Enfeeble",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/4/40/Enfeeble_icon.png?version=c278ba13fb3d72a837c1ab28fc87243f",
+      "link": "http://dota2.gamepedia.com/Bane#Enfeeble"
+    },
+    {
+      "name": "Brain Sap",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/0/0c/Brain_Sap_icon.png?version=d5d9c906851321ee3b7fe166419f7ad0",
+      "link": "http://dota2.gamepedia.com/Bane#Brain_Sap"
+    },
+    {
+      "name": "Nightmare",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/6/6e/Nightmare_icon.png?version=528239e01e34939a32efa21c2026dfa7",
+      "link": "http://dota2.gamepedia.com/Bane#Nightmare"
+    },
+    {
+      "name": "Fiend's Grip",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/7/7b/Fiend%27s_Grip_icon.png?version=5de97c308cc781d8c497fe58fb0afa0b",
+      "link": "http://dota2.gamepedia.com/Bane#Fiend.27s_Grip"
+    }
+  ]
+}

--- a/Metadata/Heroes/npc_dota_hero_batrider.json
+++ b/Metadata/Heroes/npc_dota_hero_batrider.json
@@ -1,0 +1,18 @@
+{
+  "id": 65,
+  "name": "npc_dota_hero_batrider",
+  "localized_name": "Batrider",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Initiator",
+    "Jungler",
+    "Disabler",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_beastmaster.json
+++ b/Metadata/Heroes/npc_dota_hero_beastmaster.json
@@ -1,0 +1,18 @@
+{
+  "id": 38,
+  "name": "npc_dota_hero_beastmaster",
+  "localized_name": "Beastmaster",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Initiator",
+    "Disabler",
+    "Durable",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_bloodseeker.json
+++ b/Metadata/Heroes/npc_dota_hero_bloodseeker.json
@@ -1,0 +1,40 @@
+{
+  "id": 4,
+  "name": "npc_dota_hero_bloodseeker",
+  "localized_name": "Bloodseeker",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Disabler",
+    "Jungler",
+    "Nuker",
+    "Initiator"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Bloodrage",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/8/8a/Bloodrage_icon.png?version=98e8206b5bde918dd92628dac252003a",
+      "link": "http://dota2.gamepedia.com/Bloodseeker#Bloodrage"
+    },
+    {
+      "name": "Blood Rite",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/8/83/Blood_Rite_icon.png?version=935f22be309b0e62888f7e2fd59aae98",
+      "link": "http://dota2.gamepedia.com/Bloodseeker#Blood_Rite"
+    },
+    {
+      "name": "Thirst",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/8/8e/Thirst_icon.png?version=41dac051af0c83a08ce154650ecb6b97",
+      "link": "http://dota2.gamepedia.com/Bloodseeker#Thirst"
+    },
+    {
+      "name": "Rupture",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/f/f4/Rupture_icon.png?version=e48144306f0447829f2532b60100208d",
+      "link": "http://dota2.gamepedia.com/Bloodseeker#Rupture"
+    }
+  ]
+}

--- a/Metadata/Heroes/npc_dota_hero_bounty_hunter.json
+++ b/Metadata/Heroes/npc_dota_hero_bounty_hunter.json
@@ -1,0 +1,16 @@
+{
+  "id": 62,
+  "name": "npc_dota_hero_bounty_hunter",
+  "localized_name": "Bounty Hunter",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Escape",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_brewmaster.json
+++ b/Metadata/Heroes/npc_dota_hero_brewmaster.json
@@ -1,0 +1,19 @@
+{
+  "id": 78,
+  "name": "npc_dota_hero_brewmaster",
+  "localized_name": "Brewmaster",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Initiator",
+    "Durable",
+    "Disabler",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_bristleback.json
+++ b/Metadata/Heroes/npc_dota_hero_bristleback.json
@@ -1,0 +1,18 @@
+{
+  "id": 99,
+  "name": "npc_dota_hero_bristleback",
+  "localized_name": "Bristleback",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Durable",
+    "Initiator",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_broodmother.json
+++ b/Metadata/Heroes/npc_dota_hero_broodmother.json
@@ -1,0 +1,18 @@
+{
+  "id": 61,
+  "name": "npc_dota_hero_broodmother",
+  "localized_name": "Broodmother",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Pusher",
+    "Escape",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_centaur.json
+++ b/Metadata/Heroes/npc_dota_hero_centaur.json
@@ -1,0 +1,19 @@
+{
+  "id": 96,
+  "name": "npc_dota_hero_centaur",
+  "localized_name": "Centaur Warrunner",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Durable",
+    "Initiator",
+    "Disabler",
+    "Nuker",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_chaos_knight.json
+++ b/Metadata/Heroes/npc_dota_hero_chaos_knight.json
@@ -1,0 +1,19 @@
+{
+  "id": 81,
+  "name": "npc_dota_hero_chaos_knight",
+  "localized_name": "Chaos Knight",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Disabler",
+    "Durable",
+    "Pusher",
+    "Initiator"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_chen.json
+++ b/Metadata/Heroes/npc_dota_hero_chen.json
@@ -1,0 +1,17 @@
+{
+  "id": 66,
+  "name": "npc_dota_hero_chen",
+  "localized_name": "Chen",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Jungler",
+    "Pusher"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_clinkz.json
+++ b/Metadata/Heroes/npc_dota_hero_clinkz.json
@@ -1,0 +1,17 @@
+{
+  "id": 56,
+  "name": "npc_dota_hero_clinkz",
+  "localized_name": "Clinkz",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Escape",
+    "Pusher"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_crystal_maiden.json
+++ b/Metadata/Heroes/npc_dota_hero_crystal_maiden.json
@@ -1,0 +1,39 @@
+{
+  "id": 5,
+  "name": "npc_dota_hero_crystal_maiden",
+  "localized_name": "Crystal Maiden",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Disabler",
+    "Nuker",
+    "Jungler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Crystal Nova",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/7/72/Crystal_Nova_icon.png?version=8957b6a54c9ed0741ca4bdc77dca5c7c",
+      "link": "http://dota2.gamepedia.com/Crystal_Maiden#Crystal_Nova"
+    },
+    {
+      "name": "Frostbite",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/d/d6/Frostbite_icon.png?version=4a23faddd60a73919459488572443d38",
+      "link": "http://dota2.gamepedia.com/Crystal_Maiden#Frostbite"
+    },
+    {
+      "name": "Arcane Aura",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/5/5a/Arcane_Aura_icon.png?version=83bbf19281a2e99cf7819575629f9328",
+      "link": "http://dota2.gamepedia.com/Crystal_Maiden#Arcane_Aura"
+    },
+    {
+      "name": "Freezing Field",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/d/de/Freezing_Field_icon.png?version=cdb839eea84cb35baae95023943a96a0",
+      "link": "http://dota2.gamepedia.com/Crystal_Maiden#Freezing_Field"
+    }
+  ]
+}

--- a/Metadata/Heroes/npc_dota_hero_dark_seer.json
+++ b/Metadata/Heroes/npc_dota_hero_dark_seer.json
@@ -1,0 +1,18 @@
+{
+  "id": 55,
+  "name": "npc_dota_hero_dark_seer",
+  "localized_name": "Dark Seer",
+  "primary_attr": "int",
+  "attack_type": "Melee",
+  "roles": [
+    "Initiator",
+    "Jungler",
+    "Escape",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_dazzle.json
+++ b/Metadata/Heroes/npc_dota_hero_dazzle.json
@@ -1,0 +1,17 @@
+{
+  "id": 50,
+  "name": "npc_dota_hero_dazzle",
+  "localized_name": "Dazzle",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Nuker",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_death_prophet.json
+++ b/Metadata/Heroes/npc_dota_hero_death_prophet.json
@@ -1,0 +1,18 @@
+{
+  "id": 43,
+  "name": "npc_dota_hero_death_prophet",
+  "localized_name": "Death Prophet",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Pusher",
+    "Nuker",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_disruptor.json
+++ b/Metadata/Heroes/npc_dota_hero_disruptor.json
@@ -1,0 +1,18 @@
+{
+  "id": 87,
+  "name": "npc_dota_hero_disruptor",
+  "localized_name": "Disruptor",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Disabler",
+    "Nuker",
+    "Initiator"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_doom_bringer.json
+++ b/Metadata/Heroes/npc_dota_hero_doom_bringer.json
@@ -1,0 +1,19 @@
+{
+  "id": 69,
+  "name": "npc_dota_hero_doom_bringer",
+  "localized_name": "Doom",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Disabler",
+    "Initiator",
+    "Durable",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_dragon_knight.json
+++ b/Metadata/Heroes/npc_dota_hero_dragon_knight.json
@@ -1,0 +1,20 @@
+{
+  "id": 49,
+  "name": "npc_dota_hero_dragon_knight",
+  "localized_name": "Dragon Knight",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Pusher",
+    "Durable",
+    "Disabler",
+    "Initiator",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_drow_ranger.json
+++ b/Metadata/Heroes/npc_dota_hero_drow_ranger.json
@@ -1,0 +1,38 @@
+{
+  "id": 6,
+  "name": "npc_dota_hero_drow_ranger",
+  "localized_name": "Drow Ranger",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Disabler",
+    "Pusher"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Frost Arrows",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/8/8f/Frost_Arrows_icon.png?version=3b4326414adb5d8e120f59adc522af8e",
+      "link": "http://dota2.gamepedia.com/Drow_Ranger#Frost_Arrows"
+    },
+    {
+      "name": "Gust",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/5/5b/Gust_icon.png?version=b339598bf597844e7b52412a68039c33",
+      "link": "http://dota2.gamepedia.com/Drow_Ranger#Gust"
+    },
+    {
+      "name": "Precision Aura",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/5/51/Precision_Aura_icon.png?version=0d41f3ac417fdc5c203a926c1abd63db",
+      "link": "http://dota2.gamepedia.com/Drow_Ranger#Precision_Aura"
+    },
+    {
+      "name": "Marksmanship",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/a/af/Marksmanship_icon.png?version=8df2fb32e67f84416beb985bc602b6ad",
+      "link": "http://dota2.gamepedia.com/Drow_Ranger#Marksmanship"
+    }
+  ]
+}

--- a/Metadata/Heroes/npc_dota_hero_earth_spirit.json
+++ b/Metadata/Heroes/npc_dota_hero_earth_spirit.json
@@ -1,0 +1,19 @@
+{
+  "id": 107,
+  "name": "npc_dota_hero_earth_spirit",
+  "localized_name": "Earth Spirit",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Nuker",
+    "Escape",
+    "Disabler",
+    "Initiator",
+    "Durable"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_earthshaker.json
+++ b/Metadata/Heroes/npc_dota_hero_earthshaker.json
@@ -1,0 +1,39 @@
+{
+  "id": 7,
+  "name": "npc_dota_hero_earthshaker",
+  "localized_name": "Earthshaker",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Support",
+    "Initiator",
+    "Disabler",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Fissure",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/2/24/Fissure_icon.png?version=d01e8f746e75ac4e5b44a0bb8449921a",
+      "link": "http://dota2.gamepedia.com/Earthshaker#Fissure"
+    },
+    {
+      "name": "Enchant Totem",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/8/8f/Enchant_Totem_icon.png?version=1009ee2b7583b7313340360e871a2142",
+      "link": "http://dota2.gamepedia.com/Earthshaker#Enchant_Totem"
+    },
+    {
+      "name": "Aftershock",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/f/f1/Aftershock_icon.png?version=6c15d43050afcff5cfc15fbc7cccc47a",
+      "link": "http://dota2.gamepedia.com/Earthshaker#Aftershock"
+    },
+    {
+      "name": "Echo Slam",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/0/01/Echo_Slam_icon.png?version=e1f1dd07d78fa2f929a7fed0238dad78",
+      "link": "http://dota2.gamepedia.com/Earthshaker#Echo_Slam"
+    }
+  ]
+}

--- a/Metadata/Heroes/npc_dota_hero_elder_titan.json
+++ b/Metadata/Heroes/npc_dota_hero_elder_titan.json
@@ -1,0 +1,18 @@
+{
+  "id": 103,
+  "name": "npc_dota_hero_elder_titan",
+  "localized_name": "Elder Titan",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Initiator",
+    "Disabler",
+    "Nuker",
+    "Durable"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_ember_spirit.json
+++ b/Metadata/Heroes/npc_dota_hero_ember_spirit.json
@@ -1,0 +1,19 @@
+{
+  "id": 106,
+  "name": "npc_dota_hero_ember_spirit",
+  "localized_name": "Ember Spirit",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Escape",
+    "Nuker",
+    "Disabler",
+    "Initiator"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_enchantress.json
+++ b/Metadata/Heroes/npc_dota_hero_enchantress.json
@@ -1,0 +1,19 @@
+{
+  "id": 58,
+  "name": "npc_dota_hero_enchantress",
+  "localized_name": "Enchantress",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Jungler",
+    "Pusher",
+    "Durable",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_enigma.json
+++ b/Metadata/Heroes/npc_dota_hero_enigma.json
@@ -1,0 +1,18 @@
+{
+  "id": 33,
+  "name": "npc_dota_hero_enigma",
+  "localized_name": "Enigma",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Disabler",
+    "Jungler",
+    "Initiator",
+    "Pusher"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_faceless_void.json
+++ b/Metadata/Heroes/npc_dota_hero_faceless_void.json
@@ -1,0 +1,19 @@
+{
+  "id": 41,
+  "name": "npc_dota_hero_faceless_void",
+  "localized_name": "Faceless Void",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Initiator",
+    "Disabler",
+    "Escape",
+    "Durable"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_furion.json
+++ b/Metadata/Heroes/npc_dota_hero_furion.json
@@ -1,0 +1,19 @@
+{
+  "id": 53,
+  "name": "npc_dota_hero_furion",
+  "localized_name": "Nature's Prophet",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Jungler",
+    "Pusher",
+    "Escape",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_gyrocopter.json
+++ b/Metadata/Heroes/npc_dota_hero_gyrocopter.json
@@ -1,0 +1,17 @@
+{
+  "id": 72,
+  "name": "npc_dota_hero_gyrocopter",
+  "localized_name": "Gyrocopter",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Nuker",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_huskar.json
+++ b/Metadata/Heroes/npc_dota_hero_huskar.json
@@ -1,0 +1,17 @@
+{
+  "id": 59,
+  "name": "npc_dota_hero_huskar",
+  "localized_name": "Huskar",
+  "primary_attr": "str",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Durable",
+    "Initiator"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_invoker.json
+++ b/Metadata/Heroes/npc_dota_hero_invoker.json
@@ -1,0 +1,19 @@
+{
+  "id": 74,
+  "name": "npc_dota_hero_invoker",
+  "localized_name": "Invoker",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Nuker",
+    "Disabler",
+    "Escape",
+    "Pusher"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_jakiro.json
+++ b/Metadata/Heroes/npc_dota_hero_jakiro.json
@@ -1,0 +1,18 @@
+{
+  "id": 64,
+  "name": "npc_dota_hero_jakiro",
+  "localized_name": "Jakiro",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Nuker",
+    "Pusher",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_juggernaut.json
+++ b/Metadata/Heroes/npc_dota_hero_juggernaut.json
@@ -1,0 +1,38 @@
+{
+  "id": 8,
+  "name": "npc_dota_hero_juggernaut",
+  "localized_name": "Juggernaut",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Pusher",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Blade Fury",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/4/4c/Blade_Fury_icon.png?version=a09b759c41208d9f1deaefc422718a51",
+      "link": "http://dota2.gamepedia.com/Juggernaut#Blade_Fury"
+    },
+    {
+      "name": "Healing Ward",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/5/58/Healing_Ward_icon.png?version=ffdd8e37c8d4422a88af230888401de9",
+      "link": "http://dota2.gamepedia.com/Juggernaut#Healing_Ward"
+    },
+    {
+      "name": "Blade Dance",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/8/83/Blade_Dance_icon.png?version=aade8b55e0657114faf0c6d57ff4e1d5",
+      "link": "http://dota2.gamepedia.com/Juggernaut#Blade_Dance"
+    },
+    {
+      "name": "Omnislash",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/3/39/Omnislash_icon.png?version=40d59d17876f17ab9e6c06fc47002f73",
+      "link": "http://dota2.gamepedia.com/Juggernaut#Omnislash"
+    }
+  ]
+}

--- a/Metadata/Heroes/npc_dota_hero_keeper_of_the_light.json
+++ b/Metadata/Heroes/npc_dota_hero_keeper_of_the_light.json
@@ -1,0 +1,18 @@
+{
+  "id": 90,
+  "name": "npc_dota_hero_keeper_of_the_light",
+  "localized_name": "Keeper of the Light",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Nuker",
+    "Disabler",
+    "Jungler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_kunkka.json
+++ b/Metadata/Heroes/npc_dota_hero_kunkka.json
@@ -1,0 +1,19 @@
+{
+  "id": 23,
+  "name": "npc_dota_hero_kunkka",
+  "localized_name": "Kunkka",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Disabler",
+    "Initiator",
+    "Durable",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_legion_commander.json
+++ b/Metadata/Heroes/npc_dota_hero_legion_commander.json
@@ -1,0 +1,19 @@
+{
+  "id": 104,
+  "name": "npc_dota_hero_legion_commander",
+  "localized_name": "Legion Commander",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Disabler",
+    "Initiator",
+    "Durable",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_leshrac.json
+++ b/Metadata/Heroes/npc_dota_hero_leshrac.json
@@ -1,0 +1,19 @@
+{
+  "id": 52,
+  "name": "npc_dota_hero_leshrac",
+  "localized_name": "Leshrac",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Support",
+    "Nuker",
+    "Pusher",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_lich.json
+++ b/Metadata/Heroes/npc_dota_hero_lich.json
@@ -1,0 +1,16 @@
+{
+  "id": 31,
+  "name": "npc_dota_hero_lich",
+  "localized_name": "Lich",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_life_stealer.json
+++ b/Metadata/Heroes/npc_dota_hero_life_stealer.json
@@ -1,0 +1,19 @@
+{
+  "id": 54,
+  "name": "npc_dota_hero_life_stealer",
+  "localized_name": "Lifestealer",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Durable",
+    "Jungler",
+    "Escape",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_lina.json
+++ b/Metadata/Heroes/npc_dota_hero_lina.json
@@ -1,0 +1,18 @@
+{
+  "id": 25,
+  "name": "npc_dota_hero_lina",
+  "localized_name": "Lina",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Carry",
+    "Nuker",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_lion.json
+++ b/Metadata/Heroes/npc_dota_hero_lion.json
@@ -1,0 +1,18 @@
+{
+  "id": 26,
+  "name": "npc_dota_hero_lion",
+  "localized_name": "Lion",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Disabler",
+    "Nuker",
+    "Initiator"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_lone_druid.json
+++ b/Metadata/Heroes/npc_dota_hero_lone_druid.json
@@ -1,0 +1,18 @@
+{
+  "id": 80,
+  "name": "npc_dota_hero_lone_druid",
+  "localized_name": "Lone Druid",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Pusher",
+    "Jungler",
+    "Durable"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_luna.json
+++ b/Metadata/Heroes/npc_dota_hero_luna.json
@@ -1,0 +1,17 @@
+{
+  "id": 48,
+  "name": "npc_dota_hero_luna",
+  "localized_name": "Luna",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Nuker",
+    "Pusher"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_lycan.json
+++ b/Metadata/Heroes/npc_dota_hero_lycan.json
@@ -1,0 +1,19 @@
+{
+  "id": 77,
+  "name": "npc_dota_hero_lycan",
+  "localized_name": "Lycan",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Pusher",
+    "Jungler",
+    "Durable",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_magnataur.json
+++ b/Metadata/Heroes/npc_dota_hero_magnataur.json
@@ -1,0 +1,18 @@
+{
+  "id": 97,
+  "name": "npc_dota_hero_magnataur",
+  "localized_name": "Magnus",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Initiator",
+    "Disabler",
+    "Nuker",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_medusa.json
+++ b/Metadata/Heroes/npc_dota_hero_medusa.json
@@ -1,0 +1,17 @@
+{
+  "id": 94,
+  "name": "npc_dota_hero_medusa",
+  "localized_name": "Medusa",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Disabler",
+    "Durable"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_meepo.json
+++ b/Metadata/Heroes/npc_dota_hero_meepo.json
@@ -1,0 +1,20 @@
+{
+  "id": 82,
+  "name": "npc_dota_hero_meepo",
+  "localized_name": "Meepo",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Escape",
+    "Nuker",
+    "Disabler",
+    "Initiator",
+    "Pusher"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_mirana.json
+++ b/Metadata/Heroes/npc_dota_hero_mirana.json
@@ -1,0 +1,40 @@
+{
+  "id": 9,
+  "name": "npc_dota_hero_mirana",
+  "localized_name": "Mirana",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Support",
+    "Escape",
+    "Nuker",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Starstorm",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/9/9e/Starstorm_icon.png?version=18d17f0e3542b7d1f12fd53229b6819d",
+      "link": "http://dota2.gamepedia.com/Mirana#Starstorm"
+    },
+    {
+      "name": "Sacred Arrow",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/4/49/Sacred_Arrow_icon.png?version=7eb555d2d9f7212a5046884af89a831e",
+      "link": "http://dota2.gamepedia.com/Mirana#Sacred_Arrow"
+    },
+    {
+      "name": "Leap",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/8/88/Leap_icon.png?version=11c1fc342212117f16d0cb594a283ca7",
+      "link": "http://dota2.gamepedia.com/Mirana#Leap"
+    },
+    {
+      "name": "Moonlight Shadow",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/6/6b/Moonlight_Shadow_icon.png?version=f4ad6deedfc25f87129337fe7fd7636d",
+      "link": "http://dota2.gamepedia.com/Mirana#Moonlight_Shadow"
+    }
+  ]
+}

--- a/Metadata/Heroes/npc_dota_hero_monkey_king.json
+++ b/Metadata/Heroes/npc_dota_hero_monkey_king.json
@@ -1,0 +1,18 @@
+{
+  "id": 114,
+  "name": "npc_dota_hero_monkey_king",
+  "localized_name": "Monkey King",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Escape",
+    "Disabler",
+    "Initiator"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_morphling.json
+++ b/Metadata/Heroes/npc_dota_hero_morphling.json
@@ -1,0 +1,45 @@
+{
+  "id": 10,
+  "name": "npc_dota_hero_morphling",
+  "localized_name": "Morphling",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Escape",
+    "Durable",
+    "Nuker",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Waveform",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/9/97/Waveform_icon.png?version=06b1c6deeb112d930a1690237cbf7ff9",
+      "link": "http://dota2.gamepedia.com/Morphling#Waveform"
+    },
+    {
+      "name": "Adaptive Strike",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/b/b0/Adaptive_Strike_icon.png?version=41db52b4d018f3d2b2c86a8886c8a6fc",
+      "link": "http://dota2.gamepedia.com/Morphling#Adaptive_Strike"
+    },
+    {
+      "name": "Morph (Agility Gain)",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/8/80/Morph_%28Agility_Gain%29_icon.png?version=8d35276815ecf538c62af208c2bd48fa",
+      "link": "http://dota2.gamepedia.com/Morphling#Morph_Agility"
+    },
+    {
+      "name": "Morph (Strength Gain)",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/7/75/Morph_%28Strength_Gain%29_icon.png?version=8802766abf6cf75fc152e5c5b5e1743a",
+      "link": "http://dota2.gamepedia.com/Morphling#Morph_Strength"
+    },
+    {
+      "name": "Morph Replicate",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/9/9f/Morph_Replicate_icon.png?version=f927d15731de5d8f977e90782f0032bc",
+      "link": "http://dota2.gamepedia.com/Morphling#Morph_Replicate"
+    }
+  ]
+}

--- a/Metadata/Heroes/npc_dota_hero_naga_siren.json
+++ b/Metadata/Heroes/npc_dota_hero_naga_siren.json
@@ -1,0 +1,20 @@
+{
+  "id": 89,
+  "name": "npc_dota_hero_naga_siren",
+  "localized_name": "Naga Siren",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Support",
+    "Pusher",
+    "Disabler",
+    "Initiator",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_necrolyte.json
+++ b/Metadata/Heroes/npc_dota_hero_necrolyte.json
@@ -1,0 +1,18 @@
+{
+  "id": 36,
+  "name": "npc_dota_hero_necrolyte",
+  "localized_name": "Necrophos",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Nuker",
+    "Durable",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_nevermore.json
+++ b/Metadata/Heroes/npc_dota_hero_nevermore.json
@@ -1,0 +1,47 @@
+{
+  "id": 11,
+  "name": "npc_dota_hero_nevermore",
+  "localized_name": "Shadow Fiend",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Shadowraze (Near)",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/7/7c/Shadowraze_%28Near%29_icon.png?version=18748228f6ea879809eb3d81ca3f34e8",
+      "link": "http://dota2.gamepedia.com/Shadow_Fiend#Shadowraze"
+    },
+    {
+      "name": "Shadowraze (Medium)",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/c/c1/Shadowraze_%28Medium%29_icon.png?version=26b6f254e7e6aee7e622967239917183",
+      "link": "http://dota2.gamepedia.com/Shadow_Fiend#Shadowraze"
+    },
+    {
+      "name": "Shadowraze (Far)",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/a/a6/Shadowraze_%28Far%29_icon.png?version=9e3cbceb0be658af40d07ec253df4e68",
+      "link": "http://dota2.gamepedia.com/Shadow_Fiend#Shadowraze"
+    },
+    {
+      "name": "Necromastery",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/9/9d/Necromastery_icon.png?version=44ed7d2493fa37bd7be46d1d3fc900ec",
+      "link": "http://dota2.gamepedia.com/Shadow_Fiend#Necromastery"
+    },
+    {
+      "name": "Presence of the Dark Lord",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/a/a6/Shadowraze_%28Far%29_icon.png?version=9e3cbceb0be658af40d07ec253df4e68",
+      "link": "http://dota2.gamepedia.com/Shadow_Fiend#Presence_of_the_Dark_Lord"
+    },
+    {
+      "name": "Requiem of Souls",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/a/a8/Requiem_of_Souls_icon.png?version=a8e8af8f109fd93756cd6b05027fe2e1",
+      "link": "http://dota2.gamepedia.com/Shadow_Fiend#Requiem_of_Souls"
+    }
+  ]
+}

--- a/Metadata/Heroes/npc_dota_hero_night_stalker.json
+++ b/Metadata/Heroes/npc_dota_hero_night_stalker.json
@@ -1,0 +1,19 @@
+{
+  "id": 60,
+  "name": "npc_dota_hero_night_stalker",
+  "localized_name": "Night Stalker",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Initiator",
+    "Durable",
+    "Disabler",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_nyx_assassin.json
+++ b/Metadata/Heroes/npc_dota_hero_nyx_assassin.json
@@ -1,0 +1,18 @@
+{
+  "id": 88,
+  "name": "npc_dota_hero_nyx_assassin",
+  "localized_name": "Nyx Assassin",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Disabler",
+    "Nuker",
+    "Initiator",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_obsidian_destroyer.json
+++ b/Metadata/Heroes/npc_dota_hero_obsidian_destroyer.json
@@ -1,0 +1,17 @@
+{
+  "id": 76,
+  "name": "npc_dota_hero_obsidian_destroyer",
+  "localized_name": "Outworld Devourer",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Nuker",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_ogre_magi.json
+++ b/Metadata/Heroes/npc_dota_hero_ogre_magi.json
@@ -1,0 +1,19 @@
+{
+  "id": 84,
+  "name": "npc_dota_hero_ogre_magi",
+  "localized_name": "Ogre Magi",
+  "primary_attr": "int",
+  "attack_type": "Melee",
+  "roles": [
+    "Support",
+    "Nuker",
+    "Disabler",
+    "Durable",
+    "Initiator"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_omniknight.json
+++ b/Metadata/Heroes/npc_dota_hero_omniknight.json
@@ -1,0 +1,17 @@
+{
+  "id": 57,
+  "name": "npc_dota_hero_omniknight",
+  "localized_name": "Omniknight",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Support",
+    "Durable",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_oracle.json
+++ b/Metadata/Heroes/npc_dota_hero_oracle.json
@@ -1,0 +1,18 @@
+{
+  "id": 111,
+  "name": "npc_dota_hero_oracle",
+  "localized_name": "Oracle",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Nuker",
+    "Disabler",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_phantom_assassin.json
+++ b/Metadata/Heroes/npc_dota_hero_phantom_assassin.json
@@ -1,0 +1,16 @@
+{
+  "id": 44,
+  "name": "npc_dota_hero_phantom_assassin",
+  "localized_name": "Phantom Assassin",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_phantom_lancer.json
+++ b/Metadata/Heroes/npc_dota_hero_phantom_lancer.json
@@ -1,0 +1,18 @@
+{
+  "id": 12,
+  "name": "npc_dota_hero_phantom_lancer",
+  "localized_name": "Phantom Lancer",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Escape",
+    "Pusher",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_phoenix.json
+++ b/Metadata/Heroes/npc_dota_hero_phoenix.json
@@ -1,0 +1,19 @@
+{
+  "id": 110,
+  "name": "npc_dota_hero_phoenix",
+  "localized_name": "Phoenix",
+  "primary_attr": "str",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Nuker",
+    "Initiator",
+    "Escape",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_puck.json
+++ b/Metadata/Heroes/npc_dota_hero_puck.json
@@ -1,0 +1,18 @@
+{
+  "id": 13,
+  "name": "npc_dota_hero_puck",
+  "localized_name": "Puck",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Initiator",
+    "Disabler",
+    "Escape",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_pudge.json
+++ b/Metadata/Heroes/npc_dota_hero_pudge.json
@@ -1,0 +1,18 @@
+{
+  "id": 14,
+  "name": "npc_dota_hero_pudge",
+  "localized_name": "Pudge",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Disabler",
+    "Initiator",
+    "Durable",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_pugna.json
+++ b/Metadata/Heroes/npc_dota_hero_pugna.json
@@ -1,0 +1,16 @@
+{
+  "id": 45,
+  "name": "npc_dota_hero_pugna",
+  "localized_name": "Pugna",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Nuker",
+    "Pusher"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_queenofpain.json
+++ b/Metadata/Heroes/npc_dota_hero_queenofpain.json
@@ -1,0 +1,17 @@
+{
+  "id": 39,
+  "name": "npc_dota_hero_queenofpain",
+  "localized_name": "Queen of Pain",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Nuker",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_rattletrap.json
+++ b/Metadata/Heroes/npc_dota_hero_rattletrap.json
@@ -1,0 +1,18 @@
+{
+  "id": 51,
+  "name": "npc_dota_hero_rattletrap",
+  "localized_name": "Clockwerk",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Initiator",
+    "Disabler",
+    "Durable",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_razor.json
+++ b/Metadata/Heroes/npc_dota_hero_razor.json
@@ -1,0 +1,18 @@
+{
+  "id": 15,
+  "name": "npc_dota_hero_razor",
+  "localized_name": "Razor",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Durable",
+    "Nuker",
+    "Pusher"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_riki.json
+++ b/Metadata/Heroes/npc_dota_hero_riki.json
@@ -1,0 +1,17 @@
+{
+  "id": 32,
+  "name": "npc_dota_hero_riki",
+  "localized_name": "Riki",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Escape",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_rubick.json
+++ b/Metadata/Heroes/npc_dota_hero_rubick.json
@@ -1,0 +1,17 @@
+{
+  "id": 86,
+  "name": "npc_dota_hero_rubick",
+  "localized_name": "Rubick",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Disabler",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_sand_king.json
+++ b/Metadata/Heroes/npc_dota_hero_sand_king.json
@@ -1,0 +1,19 @@
+{
+  "id": 16,
+  "name": "npc_dota_hero_sand_king",
+  "localized_name": "Sand King",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Initiator",
+    "Disabler",
+    "Nuker",
+    "Escape",
+    "Jungler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_shadow_demon.json
+++ b/Metadata/Heroes/npc_dota_hero_shadow_demon.json
@@ -1,0 +1,18 @@
+{
+  "id": 79,
+  "name": "npc_dota_hero_shadow_demon",
+  "localized_name": "Shadow Demon",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Disabler",
+    "Initiator",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_shadow_shaman.json
+++ b/Metadata/Heroes/npc_dota_hero_shadow_shaman.json
@@ -1,0 +1,19 @@
+{
+  "id": 27,
+  "name": "npc_dota_hero_shadow_shaman",
+  "localized_name": "Shadow Shaman",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Pusher",
+    "Disabler",
+    "Nuker",
+    "Initiator"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_shredder.json
+++ b/Metadata/Heroes/npc_dota_hero_shredder.json
@@ -1,0 +1,17 @@
+{
+  "id": 98,
+  "name": "npc_dota_hero_shredder",
+  "localized_name": "Timbersaw",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Nuker",
+    "Durable",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_silencer.json
+++ b/Metadata/Heroes/npc_dota_hero_silencer.json
@@ -1,0 +1,19 @@
+{
+  "id": 75,
+  "name": "npc_dota_hero_silencer",
+  "localized_name": "Silencer",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Support",
+    "Disabler",
+    "Initiator",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_skeleton_king.json
+++ b/Metadata/Heroes/npc_dota_hero_skeleton_king.json
@@ -1,0 +1,19 @@
+{
+  "id": 42,
+  "name": "npc_dota_hero_skeleton_king",
+  "localized_name": "Wraith King",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Support",
+    "Durable",
+    "Disabler",
+    "Initiator"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_skywrath_mage.json
+++ b/Metadata/Heroes/npc_dota_hero_skywrath_mage.json
@@ -1,0 +1,17 @@
+{
+  "id": 101,
+  "name": "npc_dota_hero_skywrath_mage",
+  "localized_name": "Skywrath Mage",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Nuker",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_slardar.json
+++ b/Metadata/Heroes/npc_dota_hero_slardar.json
@@ -1,0 +1,19 @@
+{
+  "id": 28,
+  "name": "npc_dota_hero_slardar",
+  "localized_name": "Slardar",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Durable",
+    "Initiator",
+    "Disabler",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_slark.json
+++ b/Metadata/Heroes/npc_dota_hero_slark.json
@@ -1,0 +1,18 @@
+{
+  "id": 93,
+  "name": "npc_dota_hero_slark",
+  "localized_name": "Slark",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Escape",
+    "Disabler",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_sniper.json
+++ b/Metadata/Heroes/npc_dota_hero_sniper.json
@@ -1,0 +1,16 @@
+{
+  "id": 35,
+  "name": "npc_dota_hero_sniper",
+  "localized_name": "Sniper",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_spectre.json
+++ b/Metadata/Heroes/npc_dota_hero_spectre.json
@@ -1,0 +1,17 @@
+{
+  "id": 67,
+  "name": "npc_dota_hero_spectre",
+  "localized_name": "Spectre",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Durable",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_spirit_breaker.json
+++ b/Metadata/Heroes/npc_dota_hero_spirit_breaker.json
@@ -1,0 +1,19 @@
+{
+  "id": 71,
+  "name": "npc_dota_hero_spirit_breaker",
+  "localized_name": "Spirit Breaker",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Initiator",
+    "Disabler",
+    "Durable",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_storm_spirit.json
+++ b/Metadata/Heroes/npc_dota_hero_storm_spirit.json
@@ -1,0 +1,19 @@
+{
+  "id": 17,
+  "name": "npc_dota_hero_storm_spirit",
+  "localized_name": "Storm Spirit",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Escape",
+    "Nuker",
+    "Initiator",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_sven.json
+++ b/Metadata/Heroes/npc_dota_hero_sven.json
@@ -1,0 +1,19 @@
+{
+  "id": 18,
+  "name": "npc_dota_hero_sven",
+  "localized_name": "Sven",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Disabler",
+    "Initiator",
+    "Durable",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_techies.json
+++ b/Metadata/Heroes/npc_dota_hero_techies.json
@@ -1,0 +1,16 @@
+{
+  "id": 105,
+  "name": "npc_dota_hero_techies",
+  "localized_name": "Techies",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Nuker",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_templar_assassin.json
+++ b/Metadata/Heroes/npc_dota_hero_templar_assassin.json
@@ -1,0 +1,16 @@
+{
+  "id": 46,
+  "name": "npc_dota_hero_templar_assassin",
+  "localized_name": "Templar Assassin",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_terrorblade.json
+++ b/Metadata/Heroes/npc_dota_hero_terrorblade.json
@@ -1,0 +1,17 @@
+{
+  "id": 109,
+  "name": "npc_dota_hero_terrorblade",
+  "localized_name": "Terrorblade",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Pusher",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_tidehunter.json
+++ b/Metadata/Heroes/npc_dota_hero_tidehunter.json
@@ -1,0 +1,18 @@
+{
+  "id": 29,
+  "name": "npc_dota_hero_tidehunter",
+  "localized_name": "Tidehunter",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Initiator",
+    "Durable",
+    "Disabler",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_tinker.json
+++ b/Metadata/Heroes/npc_dota_hero_tinker.json
@@ -1,0 +1,17 @@
+{
+  "id": 34,
+  "name": "npc_dota_hero_tinker",
+  "localized_name": "Tinker",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Nuker",
+    "Pusher"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_tiny.json
+++ b/Metadata/Heroes/npc_dota_hero_tiny.json
@@ -1,0 +1,20 @@
+{
+  "id": 19,
+  "name": "npc_dota_hero_tiny",
+  "localized_name": "Tiny",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Nuker",
+    "Pusher",
+    "Initiator",
+    "Durable",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_treant.json
+++ b/Metadata/Heroes/npc_dota_hero_treant.json
@@ -1,0 +1,19 @@
+{
+  "id": 83,
+  "name": "npc_dota_hero_treant",
+  "localized_name": "Treant Protector",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Support",
+    "Initiator",
+    "Durable",
+    "Disabler",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_troll_warlord.json
+++ b/Metadata/Heroes/npc_dota_hero_troll_warlord.json
@@ -1,0 +1,18 @@
+{
+  "id": 95,
+  "name": "npc_dota_hero_troll_warlord",
+  "localized_name": "Troll Warlord",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Pusher",
+    "Disabler",
+    "Durable"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_tusk.json
+++ b/Metadata/Heroes/npc_dota_hero_tusk.json
@@ -1,0 +1,17 @@
+{
+  "id": 100,
+  "name": "npc_dota_hero_tusk",
+  "localized_name": "Tusk",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Initiator",
+    "Disabler",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_undying.json
+++ b/Metadata/Heroes/npc_dota_hero_undying.json
@@ -1,0 +1,18 @@
+{
+  "id": 85,
+  "name": "npc_dota_hero_undying",
+  "localized_name": "Undying",
+  "primary_attr": "str",
+  "attack_type": "Melee",
+  "roles": [
+    "Support",
+    "Durable",
+    "Disabler",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_ursa.json
+++ b/Metadata/Heroes/npc_dota_hero_ursa.json
@@ -1,0 +1,18 @@
+{
+  "id": 70,
+  "name": "npc_dota_hero_ursa",
+  "localized_name": "Ursa",
+  "primary_attr": "agi",
+  "attack_type": "Melee",
+  "roles": [
+    "Carry",
+    "Jungler",
+    "Durable",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_vengefulspirit.json
+++ b/Metadata/Heroes/npc_dota_hero_vengefulspirit.json
@@ -1,0 +1,19 @@
+{
+  "id": 20,
+  "name": "npc_dota_hero_vengefulspirit",
+  "localized_name": "Vengeful Spirit",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Initiator",
+    "Disabler",
+    "Nuker",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_venomancer.json
+++ b/Metadata/Heroes/npc_dota_hero_venomancer.json
@@ -1,0 +1,19 @@
+{
+  "id": 40,
+  "name": "npc_dota_hero_venomancer",
+  "localized_name": "Venomancer",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Nuker",
+    "Initiator",
+    "Pusher",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_viper.json
+++ b/Metadata/Heroes/npc_dota_hero_viper.json
@@ -1,0 +1,18 @@
+{
+  "id": 47,
+  "name": "npc_dota_hero_viper",
+  "localized_name": "Viper",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Durable",
+    "Initiator",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_visage.json
+++ b/Metadata/Heroes/npc_dota_hero_visage.json
@@ -1,0 +1,19 @@
+{
+  "id": 92,
+  "name": "npc_dota_hero_visage",
+  "localized_name": "Visage",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Nuker",
+    "Durable",
+    "Disabler",
+    "Pusher"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_warlock.json
+++ b/Metadata/Heroes/npc_dota_hero_warlock.json
@@ -1,0 +1,17 @@
+{
+  "id": 37,
+  "name": "npc_dota_hero_warlock",
+  "localized_name": "Warlock",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Initiator",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_weaver.json
+++ b/Metadata/Heroes/npc_dota_hero_weaver.json
@@ -1,0 +1,16 @@
+{
+  "id": 63,
+  "name": "npc_dota_hero_weaver",
+  "localized_name": "Weaver",
+  "primary_attr": "agi",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Escape"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_windrunner.json
+++ b/Metadata/Heroes/npc_dota_hero_windrunner.json
@@ -1,0 +1,19 @@
+{
+  "id": 21,
+  "name": "npc_dota_hero_windrunner",
+  "localized_name": "Windranger",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Carry",
+    "Support",
+    "Disabler",
+    "Escape",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_winter_wyvern.json
+++ b/Metadata/Heroes/npc_dota_hero_winter_wyvern.json
@@ -1,0 +1,17 @@
+{
+  "id": 112,
+  "name": "npc_dota_hero_winter_wyvern",
+  "localized_name": "Winter Wyvern",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Disabler",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_wisp.json
+++ b/Metadata/Heroes/npc_dota_hero_wisp.json
@@ -1,0 +1,17 @@
+{
+  "id": 91,
+  "name": "npc_dota_hero_wisp",
+  "localized_name": "Io",
+  "primary_attr": "str",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Escape",
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}

--- a/Metadata/Heroes/npc_dota_hero_witch_doctor.json
+++ b/Metadata/Heroes/npc_dota_hero_witch_doctor.json
@@ -1,0 +1,38 @@
+{
+  "id": 30,
+  "name": "npc_dota_hero_witch_doctor",
+  "localized_name": "Witch Doctor",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Support",
+    "Nuker",
+    "Disabler"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": [
+    {
+      "name": "Paralyzing Cask",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/d/dd/Paralyzing_Cask_icon.png?version=86c507955672ae485c41792a267c330a",
+      "link": "http://dota2.gamepedia.com/Witch_Doctor#Paralyzing_Cask"
+    },
+    {
+      "name": "Voodoo Restoration",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/1/11/Voodoo_Restoration_icon.png?version=025efdc8db20837efc6128ee92814b07",
+      "link": "http://dota2.gamepedia.com/Witch_Doctor#Voodoo_Restoration"
+    },
+    {
+      "name": "Maledict",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/4/42/Maledict_icon.png?version=ec120aedb0a342091d9e15ccbe2ca0f6",
+      "link": "http://dota2.gamepedia.com/Witch_Doctor#Maledict"
+    },
+    {
+      "name": "Death Ward",
+      "image": "https://hydra-media.cursecdn.com/dota2.gamepedia.com/c/cf/Death_Ward_icon.png?version=76c978406d5ce8f492e1ee4ba5b48342",
+      "link": "http://dota2.gamepedia.com/Witch_Doctor#Death_Ward"
+    }
+  ]
+}

--- a/Metadata/Heroes/npc_dota_hero_zuus.json
+++ b/Metadata/Heroes/npc_dota_hero_zuus.json
@@ -1,0 +1,15 @@
+{
+  "id": 22,
+  "name": "npc_dota_hero_zuus",
+  "localized_name": "Zeus",
+  "primary_attr": "int",
+  "attack_type": "Ranged",
+  "roles": [
+    "Nuker"
+  ],
+  "description": "",
+  "lore": "",
+  "image": "",
+  "aliases": [],
+  "skills": null
+}


### PR DESCRIPTION
Right now, we have three files for hero metadata. I propose to merge them into single format where each hero has its own JSON file from which we can build any other indexes we want. We can use this to generate a JSON file to import into LUIS as well.